### PR TITLE
Travis-ci: added support for ppc64le & Added 14 nodejs version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,21 @@
 language: node_js
 sudo: false
+arch:
+  - amd64
+  - ppc64le
 node_js:
   - 0.8
   - "0.10"
   - "0.12"
+  - "14"
   - "iojs"
+jobs:
+  exclude:
+     - nodejs: 0.8
+       arch: ppc64le
+     - nodejs: 0.10
+       arch: ppc64le
+     - nodejs: 0.12
+       arch: ppc64le
 before_install:
   - (node -v | grep v0.8 && npm install npm@1.4 -g) || echo 'npm upgrade not needed'


### PR DESCRIPTION
Hi,

I had added ppc64le(Linux on Power) architecture support & Added 14 nodejs version & excluded unsupported versions for ppc64le on Travis-CI in the PR and looks like its been successfully added.

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Regards,
Devendra